### PR TITLE
Typo in logseq storages path; formatting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 # Logseq Citations Plugin
 
 ## BREAKING CHANGE in 2.0.0
-- Version 2.0.0 had a breaking change. You will have to reconfigure the .bib export. It now has to be located in .logseq/storage/logseq-citation-manager and in settings, you just give the filename with extension(like starred-items.bib), no need for the file path.
+- Version 2.0.0 had a breaking change. You will have to reconfigure the `.bib` export. It now has to be located in `~/.logseq/storages/logseq-citation-manager` and in settings, you just give the filename with extension (like `starred-items.bib`), no need for the file path.
 
 ## Installation
 - This plugin can be installed from the Logseq marketplace


### PR DESCRIPTION
The path Logseq appears to want is ~/.logseq/storages/logseq-citation-manager. The README said `.../storage/...` – a small typo. I also added some formatting for paths and extensions to draw attention to them.