### PR TITLE
Fixes #57; clarify behavior in plugin settings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^18.0.0",
     "react-input-switch": "^2.2.2",
     "react-use": "^17.3.2",
-    "rn-segmented-control": "^1.1.2"
+    "rn-segmented-control": "^1.1.2",
+    "validator": "^13.9.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ specifiers:
   rn-segmented-control: ^1.1.2
   semantic-release: 19.0.2
   typescript: 4.6.3
+  validator: ^13.9.0
   vite: 2.9.1
   vite-plugin-logseq: 1.1.1
   vite-plugin-windicss: 1.8.3
@@ -41,6 +42,7 @@ dependencies:
   react-input-switch: 2.2.2_biqbaboplfbrettd7655fr4n2y
   react-use: 17.4.0_biqbaboplfbrettd7655fr4n2y
   rn-segmented-control: 1.1.2_react@18.2.0
+  validator: 13.9.0
 
 devDependencies:
   '@semantic-release/changelog': 6.0.1_semantic-release@19.0.2
@@ -4392,6 +4394,11 @@ packages:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /validator/13.9.0:
+    resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /vite-plugin-logseq/1.1.1:
     resolution: {integrity: sha512-WONgtk3nY2OfEKT/65UDDNI6ioTLUpqdwucaXPSde/YNVp2sUC5ZCWBBJkycvFp4NpJW8XzdMrg9rxpprcfrKQ==}


### PR DESCRIPTION
URLs must be prefixed with a protocol to pass validation (and for
`axios` to understand the URL). Upon triggering a "Reindex Citations DB"
this `fetchDatabase` (formerly `getPaperPile`) will attempt to download
BibTeX hosted at a given URL.

Adds `validator` as a dependency (to validate URLs). Also clarifies new behavior in plugin settings. I used Markdown when writing the description, because [these lines](https://github.com/logseq/logseq/blob/58d1928cde531a775c1fe644841fbcb4c658a525/libs/src/LSPlugin.ts#L239-L248) of the `SettingSchemaDesc` seem to point to `description` supporting Markdown. _However, there are a few Logseq plugins that confirm that this isn't necessarily true (perhaps in `0.8.17`?)_, so if you think we should remove it, feel free! 🙂