### PR TITLE
Resolves #44 Format fileTemplate for JabRef bib file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-citation-manager",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A citation manager plugin for logseq, integrating Paperpile, Zotero and any Bibtex exportable citation manager",
   "main": "dist/index.html",
   "scripts": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -219,9 +219,11 @@ const getPaperPile = async () => {
   // ...
 
   if (await storageBucket.hasItem(`${logseq.settings.citationReferenceDB}`)) {
-    paperpile = await storageBucket.getItem(
-      `${logseq.settings.citationReferenceDB}`
-    );
+    let tempPaperpile = await storageBucket.getItem(`${logseq.settings.citationReferenceDB}`);
+    // Remove crossref field to avoid circular references
+    tempPaperpile = tempPaperpile.replace(/^\s*crossref\s*=\s*{[^}]*},?\s*$/gm, '');
+    // Assign the processed data to the global variable paperpile
+    paperpile = tempPaperpile;
     createDB();
   }
   else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,6 +78,11 @@ const parseTemplate = (text) => {
   template = template.replaceAll("{file++}", () => {
     let text = "";
     fields.file?.forEach((individualFile) => {
+      // Check if the individualFile starts with ':'
+      if (individualFile.startsWith(':')) {
+        // Remove the leading ':' and the trailing ':PDF' or any similar file type suffix
+        individualFile = individualFile.replace(/^:|:.*$/g, '');
+      }
       text =
         text +
         `${logseq.settings.fileTemplate


### PR DESCRIPTION
This pull request resolves #44

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `3.2.0` to `3.2.1`.

### Data Processing:
* [`src/main.tsx`](diffhunk://#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811L222-R226): Modified the `getPaperPile` function to remove the `crossref` field from the citation data to avoid circular references before assigning it to the global variable `paperpile`.

### Template Parsing:
* [`src/utils.ts`](diffhunk://#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R81-R85): Enhanced the `parseTemplate` function to handle file paths that start with a colon (`:`) by removing the leading colon and any trailing file type suffix (e.g., `:PDF`).