### PR TITLE
Handle missing authors in search gracefully

### DIFF
--- a/src/searchbar.tsx
+++ b/src/searchbar.tsx
@@ -58,7 +58,8 @@ const SearchBar: React.FC<{ paperpileParsed }> = (paperpileParsed, uuid) => {
                 title: item.fields.title[0],
                 citekey: item.key,
                 // All authors joined into a single string
-                authors: item.fields.author.toString().toLowerCase().replaceAll(/,/g, ""),
+                authors: item.fields.author?.length > 0 ? item.fields.author.toString().toLowerCase().replaceAll(/,/g, "") : (
+                  item.fields.editor?.length > 0 ? item.fields.editor.toString().toLowerCase().replaceAll(/,/g, "") : ""),
                 abstract: item.fields.abstract,
               };
             } else {


### PR DESCRIPTION
Closes #62 

This is supposed to handle a missing author field gracefully in the search bar. To the best of my understanding, currently a missing field would produce an error which is caught by the later catch statement and the item would just disappear.

Sorry, I tried to test this locally before submitting but Logseq wouldn't let me add an identically named plugin next to my marketplace version and I wasn't quite certain enough that my production data would be retained to risk it.